### PR TITLE
Replaced GetLocationFromPosition() with a universal implementation

### DIFF
--- a/Neuro/Utils/Methods.cs
+++ b/Neuro/Utils/Methods.cs
@@ -24,7 +24,7 @@ public static class Methods
                 else
                     return room.DisplayName(); // If we're inside a proper room, ignore the nearPrefix
             }
-            else
+            else if (room.RoomId != SystemTypes.Hallway)
             {
                 float distance = Vector2.Distance(position, collider.ClosestPoint(position));
                 if (distance < closestDistance)
@@ -34,6 +34,9 @@ public static class Methods
                 }
             }
         }
+
+        if (!closestLocation)
+            return "";
 
         // We're not in an actual room, so say which room we're nearest to
         return nearPrefix + closestLocation.DisplayName();

--- a/Neuro/Utils/Methods.cs
+++ b/Neuro/Utils/Methods.cs
@@ -6,7 +6,7 @@ namespace Neuro.Utils;
 
 public static class Methods
 {
-    public static string GetLocationFromPosition(Vector2 position, bool excludeHallways = true)
+    public static string GetLocationFromPosition(Vector2 position, bool includeHallways = false)
     {
         float closestDistance = Mathf.Infinity;
         PlainShipRoom closestLocation = null;
@@ -17,7 +17,7 @@ public static class Methods
         foreach (PlainShipRoom room in ShipStatus.Instance.AllRooms)
         {
             // Only include actual rooms (not hallways), if required
-            if (excludeHallways && room.RoomId == SystemTypes.Hallway)
+            if (!includeHallways && room.RoomId == SystemTypes.Hallway)
                 continue;
 
             Collider2D collider = room.roomArea;

--- a/Neuro/Utils/Methods.cs
+++ b/Neuro/Utils/Methods.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace Neuro.Utils;

--- a/Neuro/Utils/Methods.cs
+++ b/Neuro/Utils/Methods.cs
@@ -11,7 +11,7 @@ public static class Methods
         PlainShipRoom closestLocation = null;
         string nearPrefix = "outside near "; // If we're not in any rooms/hallways, we're "outside"
 
-        if (ShipStatus.Instance == null) // In case this is called from the lobby
+        if (!ShipStatus.Instance) // In case this is called from the lobby
             return "the lobby";
 
         foreach (PlainShipRoom room in ShipStatus.Instance.AllRooms)

--- a/Neuro/Utils/Methods.cs
+++ b/Neuro/Utils/Methods.cs
@@ -48,8 +48,8 @@ public static class Methods
         {
             case SystemTypes.LifeSupp: return "O2";
             case SystemTypes.Nav: return "Navigation";
-            case SystemTypes.Decontamination2: return "Decontamination";
-            case SystemTypes.Decontamination3: return "Decontamination";
+            case SystemTypes.Decontamination2: return "Upper Decontamination"; // Used on Polus
+            case SystemTypes.Decontamination3: return "Lower Decontamination"; // Used on Polus
             default: return Regex.Replace(room.RoomId.ToString(), "(\\B[A-Z])", " $1"); // Adds spaces to CamelCase strings
         }
     }


### PR DESCRIPTION
This PR replaces GetLocationFromPosition() with a generic version that will work on any map, using the game's internal list of rooms and their boundaries to determine the room a co-ordinate is in (or the nearest room, if they're not in one of the rooms).

Because it uses the actual boundaries of the rooms, it should also be more accurate than the original implementation. If a player is not in a room, but in a hallway, it will return "a hallway near Electrical", for example. On Polus, "outside near Electrical", etc. is also used.

This partially addresses Issue #6.