### PR TITLE
Vision improvements & fixes

### DIFF
--- a/Neuro/Patches/PlayerControl_Patches.cs
+++ b/Neuro/Patches/PlayerControl_Patches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Reactor.Utilities;
+using UnityEngine;
 
 namespace Neuro.Patches;
 
@@ -18,5 +19,28 @@ public static class PlayerControlFixedUpdate
     public static void Postfix(PlayerControl __instance)
     {
         if (PlayerControl.LocalPlayer == __instance) PluginSingleton<NeuroPlugin>.Instance.FixedUpdate(__instance);
+    }
+}
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.Die))]
+public static class PlayerControl_Die
+{
+    public static void Postfix(DeathReason reason, PlayerControl __instance)
+    {
+        // Check if player was murdered
+        if (reason == DeathReason.Kill)
+        {
+            // Find dead body at death position
+            Collider2D[] deathPointColliders = Physics2D.OverlapCircleAll(__instance.GetTruePosition(), 1f);
+            foreach (Collider2D col in deathPointColliders)
+            {
+                // Call vision method for handling new dead bodies
+                DeadBody deadBody = col.gameObject.GetComponent<DeadBody>();
+                if (deadBody)
+                {
+                    PluginSingleton<NeuroPlugin>.Instance.vision.DeadBodyAppeared(deadBody);
+                }
+            }
+        }
     }
 }

--- a/Neuro/Vision.cs
+++ b/Neuro/Vision.cs
@@ -15,6 +15,7 @@ public class Vision
 
     public float roundStartTime = 0f; // in seconds
     public float lastPlayerUpdateTime = 0f; // in seconds, records the last time PlayerControl.FixedUpdate was called
+    public float lastPlayerUpdateDuration = 0f; // in seconds, records the time elapsed since last PlayerControl.FixedUpdate was called
 
     public Vector2 directionToNearestBody;
 
@@ -69,7 +70,8 @@ public class Vision
         }
     }
 
-    public void MeetingEnd() {
+    public void MeetingEnd()
+    {
         // Keep track of what time the round started
         roundStartTime = Time.timeSinceLevelLoad;
 
@@ -85,9 +87,14 @@ public class Vision
     public void UpdateVision()
     {
         // Keep track of the amount of time it has been since the last time we were in this function
-        float timeSinceLastUpdate = Time.timeSinceLevelLoad - lastPlayerUpdateTime;
+        lastPlayerUpdateDuration = Time.timeSinceLevelLoad - lastPlayerUpdateTime;
         lastPlayerUpdateTime = Time.timeSinceLevelLoad;
 
+        UpdateDeadBodiesVision();
+        UpdateNearbyPlayersVision();
+    }
+
+    void UpdateDeadBodiesVision() {
         // TODO: Fix this
         deadBodies = GameObject.FindObjectsOfType<DeadBody>();
 
@@ -128,7 +135,9 @@ public class Vision
                 Debug.Log(playerControl.name + " is dead in " + Methods.GetLocationFromPosition(playerControl.transform.position));
             }
         }
+    }
 
+    void UpdateNearbyPlayersVision() {
         foreach (PlayerControl playerControl in playerControls.Values)
         {
             if (PlayerControl.LocalPlayer == playerControl) continue;
@@ -142,7 +151,7 @@ public class Vision
                 LastSeenPlayer previousSighting = playerLocations[playerControl];
 
                 // If we were able to see them during our last update (~30 ms ago), and now they're in a vent, we must have seen them enter the vent
-                if (previousSighting.time > Time.timeSinceLevelLoad - (2 * timeSinceLastUpdate))
+                if (previousSighting.time > Time.timeSinceLevelLoad - (2 * lastPlayerUpdateDuration))
                 {
                     previousSighting.sawVent = true; // Remember that we saw this player vent
                     Debug.Log(playerControl.name + " vented right in front of me!");
@@ -169,8 +178,8 @@ public class Vision
                         playerLocations[playerControl].location = Methods.GetLocationFromPosition(playerControl.transform.position);
                         playerLocations[playerControl].time = Time.timeSinceLevelLoad;
                         playerLocations[playerControl].dead = false;
-                        playerLocations[playerControl].gameTimeVisible += timeSinceLastUpdate; // Keep track of total time we've been able to see this player
-                        playerLocations[playerControl].roundTimeVisible += timeSinceLastUpdate; // Keep track of time this round we've been able to see this player
+                        playerLocations[playerControl].gameTimeVisible += lastPlayerUpdateDuration; // Keep track of total time we've been able to see this player
+                        playerLocations[playerControl].roundTimeVisible += lastPlayerUpdateDuration; // Keep track of time this round we've been able to see this player
 
                         Debug.Log(playerControl.name + " is in " + Methods.GetLocationFromPosition(playerControl.transform.position));
                     }

--- a/Neuro/Vision.cs
+++ b/Neuro/Vision.cs
@@ -7,7 +7,7 @@ namespace Neuro;
 
 public class Vision
 {
-    public DeadBody[] deadBodies = null;
+    public List<DeadBody> deadBodies = new List<DeadBody>();
 
     public Dictionary<PlayerControl, LastSeenPlayer> playerLocations = new Dictionary<PlayerControl, LastSeenPlayer>();
 
@@ -81,8 +81,17 @@ public class Vision
             if (playerLocation.Key == PlayerControl.LocalPlayer || playerLocation.Value.location == "") continue;
             playerLocation.Value.roundTimeVisible = 0f;
         }
+
+        // Reset dead bodies
+        deadBodies.Clear();
     }
-        
+
+    public void DeadBodyAppeared(DeadBody deadBody)
+    {
+        Debug.Log(String.Format("{0} has been killed", playerControls[deadBody.ParentId].Data.PlayerName));
+        deadBodies.Add(deadBody);
+    }
+
     // Called from FixedUpdate
     public void UpdateVision()
     {
@@ -95,9 +104,6 @@ public class Vision
     }
 
     void UpdateDeadBodiesVision() {
-        // TODO: Fix this
-        deadBodies = GameObject.FindObjectsOfType<DeadBody>();
-
         directionToNearestBody = Vector2.zero;
         float nearestBodyDistance = Mathf.Infinity;
 


### PR DESCRIPTION
1) Cleaned up a little bit by spliting up UpdateVision function because it was starting to get too big

2) Replaced FindObjectsOfType(DeadBody) with a patch to Die that detects the body body by Physics2D.OverlapCircleAll at death point. Couldn't find a more direct way to fetch the bady, so this is somewhat of a workaround.
This also means that deadBodies list is no longer updated every frame, but only when someone is killed or a meeting is called (which is when dead bodies are cleared).

3) Fixed raycast that was supposed to check if a player is visible. I noticed that, when player is hidden, there appears an overlap with Shadow layer on the raycast, and used that for detection. It doesn't work if player stands on the very edge of the shadow while visually being 100% invisible, but the margin is really tiny so shouldn't affect that much.