### PR TITLE
Added vscode support files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,11 @@
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Neuro/Neuro.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
So, I know committing IDE specific files is contentious (I hate doing it), but getting .Net projects to run right in VS Code has been a bit of an issue for me in the past, so after getting it to run, I thought I'd commit the two files that should make it much easier to use.

Now, after following the readme, just open the project in VS Code, install the C# plugin if you don't have it, and run the 'build' task.

![image](https://user-images.githubusercontent.com/770655/227631727-adfa60e8-63b0-439a-b410-1e333ddff947.png)

Which should build the dll successfully:
![image](https://user-images.githubusercontent.com/770655/227631971-04a97e7b-5d44-43c9-b687-0675ad7fddca.png)

This just leaves the manual step of symlinking the dll into your amongus folder; I see that the csproj is set up do do that, but it didn't work for me. (Unsure if this is a VS Code thing, or not.) But a manual `ln -s` call (thank you git for windows and your unix tools) and it was right as rain.

Even if this merge is rejected, this pull request can serve as documentation on how to get it working.

