### PR TITLE
Task fixes

### DIFF
--- a/Neuro/NeuroPlugin.cs
+++ b/Neuro/NeuroPlugin.cs
@@ -67,8 +67,11 @@ public partial class NeuroPlugin : BasePlugin
         {
             foreach (PlayerTask task in localPlayer.myTasks)
             {
-                if (task == null || task.Locations == null) continue;
+                // Must be in this order or else breaks Wires task
+                if (task == null) continue;
                 if (task.IsComplete || inMinigame) continue;
+                if (task.Locations == null) continue;
+
                 foreach (Vector2 location in task.Locations)
                 {
                     if (Vector2.Distance(location, PlayerControl.LocalPlayer.transform.position) < 0.8f)

--- a/Neuro/NeuroPlugin.cs
+++ b/Neuro/NeuroPlugin.cs
@@ -78,7 +78,6 @@ public partial class NeuroPlugin : BasePlugin
                             var minigame = GameObject.Instantiate(task.GetMinigamePrefab());
                             minigame.transform.SetParent(Camera.main.transform, false);
                             minigame.transform.localPosition = new Vector3(0f, 0f, -50f);
-                            minigame.Console = GameObject.FindObjectOfType<Console>();
                             minigame.Begin(task);
                             inMinigame = true;
                         }

--- a/Neuro/Patches/Minigame_Patches.cs
+++ b/Neuro/Patches/Minigame_Patches.cs
@@ -25,10 +25,16 @@ public static class Minigame_Begin
     {
         yield return new WaitForSeconds(time);
 
-        //task.Complete();
         if (task.TryCast<NormalPlayerTask>() is NormalPlayerTask normalPlayerTask)
         {
             normalPlayerTask.NextStep();
+            Debug.Log(String.Format("Task {0} is at step {1}/{2}", normalPlayerTask, normalPlayerTask.TaskStep, normalPlayerTask.MaxStep));
+
+            // If NextStep() doesn't create an arrow, then this task does not require moving
+            // to a different location and should be completed.
+            if (normalPlayerTask.Arrow == null) {
+                normalPlayerTask.Complete();
+            }
         }
         else
         {


### PR DESCRIPTION
I've run through every NormalPlayerTask in Skeld and did a few fixes to the auto completion functions

1) Fixed (?) issue #12. Removed the following line:
`minigame.Console = GameObject.FindObjectOfType<Console>();`
I'm not sure what it was for, and I've seen others wondering about it as well. All NormalPlayerTasks work without it.

2) There was an error happening after Wires task is completed, inside the func that gets Locations for task. Since it was happening only when task is completed, fixed by rearranging the code

3) Improved the thing that is supposed to handle long tasks across multiple rooms. The problem was it affected long tasks that are in one location only. When task is completed and NextStep() is called, added a check to see if next step is in another room