### PR TITLE
Add materials with valid shaders to line renderers to allow for proper colorization

### DIFF
--- a/Neuro/NeuroPlugin.cs
+++ b/Neuro/NeuroPlugin.cs
@@ -53,8 +53,14 @@ public partial class NeuroPlugin : BasePlugin
 
         pathfinding.FloodFill(shipStatus.MeetingSpawnCenter + (Vector2.up * shipStatus.SpawnRadius) + new Vector2(0f, 0.3636f));
 
-        GameObject arrowGO = new GameObject("Arrow");
-        arrow = arrowGO.AddComponent<LineRenderer>();
+        GameObject arrowGo = new GameObject("Arrow");
+        arrow = arrowGo.AddComponent<LineRenderer>();
+        arrow.startWidth = 0.4f;
+        arrow.endWidth = 0.05f;
+        arrow.positionCount = 2;
+        arrow.material = new Material(Shader.Find("Sprites/Default"));
+        arrow.startColor = Color.blue;
+        arrow.endColor = Color.cyan;
     }
 
     public void FixedUpdate(PlayerControl localPlayer)
@@ -145,9 +151,6 @@ public partial class NeuroPlugin : BasePlugin
             LineRenderer renderer = arrow;
             renderer.SetPosition(0, PlayerControl.LocalPlayer.GetTruePosition());
             renderer.SetPosition(1, PlayerControl.LocalPlayer.GetTruePosition() + directionToNearestTask);
-            renderer.widthMultiplier = 0.1f;
-            renderer.positionCount = 2;
-            renderer.startColor = Color.red;
         }
         else
         {

--- a/Neuro/Pathfinding.cs
+++ b/Neuro/Pathfinding.cs
@@ -76,18 +76,22 @@ public class Pathfinding
             }
         }
 
+        var nodeMaterial = new Material(Shader.Find("Unlit/MaskShader"));
         foreach (Node node in closedSet.ToList())
         {
-            GameObject test = new GameObject("Test");
-            //Debug.Log(test.transform);
-            test.transform.position = (Vector3)node.worldPosition;
+            GameObject nodeVisualPoint = new GameObject("Node Visual Point");
 
-            LineRenderer renderer = test.AddComponent<LineRenderer>();
-            renderer.SetPosition(0, test.transform.position);
-            renderer.SetPosition(1, test.transform.position + new Vector3(0, 0.1f, 0));
+            var position = (Vector3)node.worldPosition;
+            nodeVisualPoint.transform.position = position;
+
+            LineRenderer renderer = nodeVisualPoint.AddComponent<LineRenderer>();
+            renderer.SetPosition(0, position);
+            renderer.SetPosition(1, position + new Vector3(0, 0.1f, 0));
             renderer.widthMultiplier = 0.1f;
             renderer.positionCount = 2;
+            renderer.material = nodeMaterial;
             renderer.startColor = Color.red;
+            renderer.endColor = Color.red;
         }
 
         // Set all nodes not in closed set to inaccessible
@@ -196,19 +200,21 @@ public class Pathfinding
         Debug.Log("End Node");
         Node targetNode = FindClosestNode(target);
 
-        GameObject endNodeObj = new GameObject("Test");
-        //Debug.Log(test.transform);
-        endNodeObj.transform.position = (Vector3)targetNode.worldPosition;
+        GameObject endNodeObj = new GameObject("Task Visual Point");
+
+        var position = (Vector3)targetNode.worldPosition;
+        endNodeObj.transform.position = position;
 
         LineRenderer renderer2 = endNodeObj.AddComponent<LineRenderer>();
-        renderer2.SetPosition(0, (Vector3)targetNode.worldPosition);
-        renderer2.SetPosition(1, (Vector3)targetNode.worldPosition + new Vector3(0f, 0.3f, 0));
+        renderer2.SetPosition(0, position);
+        renderer2.SetPosition(1, position + new Vector3(0f, 0.3f, 0));
         renderer2.widthMultiplier = 0.3f;
         renderer2.positionCount = 2;
+        renderer2.material = new Material(Shader.Find("Unlit/MaskShader"));
         renderer2.startColor = Color.blue;
+        renderer2.endColor = Color.blue;
 
-        Debug.Log(startNode.worldPosition.ToString());
-        Debug.Log(targetNode.worldPosition.ToString());
+        Debug.Log($"startNode: {startNode.worldPosition} targetNode: {targetNode.worldPosition}");
 
         if (startNode == null || targetNode == null || !startNode.accessible || !targetNode.accessible)
         {
@@ -263,7 +269,7 @@ public class Pathfinding
                         openSet.UpdateItem(neighbour);
                     }
                 }
-                    
+
             }
         }
 


### PR DESCRIPTION
After combing through a few thousand `Debug.Log`s, theses seem to be the only shaders available in the base game:
```
[Message:     Unity] matName: MaskingShader (Instance) shaderName: Unlit/MaskShader
[Message:     Unity] matName: HighlightMat (Instance) shaderName: Sprites/Outline
[Message:     Unity] matName: Sprites-Default (Instance) shaderName: Sprites/Default
```
`Unlit/MaskShader` is affected by fog of war, `Sprites/Outline` behaved weirdly so I'm not touching it again, and `Sprites/Default` seemed to behave like a typical unlit shader.

In-game screenshot:
![image](https://user-images.githubusercontent.com/72096833/227669502-74c548b1-1c7c-4a01-bcad-26acc6ef2c3c.png)
