### PR TITLE
Fix flood fill not working on Mira or Airship

### DIFF
--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -8,7 +8,7 @@ namespace Neuro.Pathfinding;
 
 public class PathfindingHandler
 {
-    private const int GRID_SIZE = 700;
+    private const int GRID_SIZE = 500;
     private const int GRID_LOWER_BOUNDS = GRID_SIZE / -2;
     private const int GRID_UPPER_BOUNDS = GRID_SIZE / 2;
 

--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -8,7 +8,7 @@ namespace Neuro.Pathfinding;
 
 public class PathfindingHandler
 {
-    private const int GRID_SIZE = 500;
+    private const int GRID_SIZE = 700;
     private const int GRID_LOWER_BOUNDS = GRID_SIZE / -2;
     private const int GRID_UPPER_BOUNDS = GRID_SIZE / 2;
 
@@ -16,10 +16,10 @@ public class PathfindingHandler
 
     public void Initialize()
     {
+        // TODO: Fix inaccessible areas on Airship
         GenerateNodeGrid();
 
-        // TODO: This currently only works for the Skeld, for Polus it might not function correctly since spawning is handled in a different way
-        FloodFill(ShipStatus.Instance.MeetingSpawnCenter + Vector2.up * ShipStatus.Instance.SpawnRadius + new Vector2(0f, 0.3636f));
+        FloodFill(ShipStatus.Instance.MeetingSpawnCenter + Vector2.down * ShipStatus.Instance.SpawnRadius);
     }
 
     public Vector2[] FindPath(Vector2 start, Vector2 target)


### PR DESCRIPTION
Also fixes the crash on Mira/Airship.

There are some issues on Airship with inaccessible areas. Also the ladders and floating platform would need some additional programming but those should be much easier than figuring out the missing grid points
![image](https://user-images.githubusercontent.com/72096833/228111953-86f43810-49fb-4e64-a334-3345a2038fba.png)
![image](https://user-images.githubusercontent.com/72096833/228111921-d50cc4c7-a512-42db-9d60-66534f96cac8.png)
![image](https://user-images.githubusercontent.com/72096833/228111938-02fc08ca-6442-40f5-a067-c2ef5127c05b.png)