### PR TITLE
Add parameter to control node grid density

### DIFF
--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -131,11 +131,12 @@ public class PathfindingHandler
             //Info(point.ToString());
             Collider2D[] cols = Physics2D.OverlapCircleAll(point, NODE_RADIUS, LayerMask.GetMask("Ship", "ShortObjects"));
             int validColsCount = cols.Count(col =>
-                    !col.isTrigger
-                    && !col.transform.name.Contains("Vent")
-                    && !col.transform.name.Contains("Door")
-                    && !col.transform.parent.name.Contains("Door")
+                !col.isTrigger
+                && !col.GetComponentInParent<Vent>()
+                && !col.GetComponentInParent<SomeKindaDoor>()
             );
+
+            // TODO: Add edge case for Airship ladders
 
             bool accessible = validColsCount == 0;
             grid[x + GRID_UPPER_BOUNDS, y + GRID_UPPER_BOUNDS] = new Node(accessible, point, x + GRID_UPPER_BOUNDS, y + GRID_UPPER_BOUNDS);
@@ -274,7 +275,7 @@ public class PathfindingHandler
         }
 
         Vector2[] waypoints = path.Select(p => p.worldPosition).ToArray();
-        Array.Reverse(waypoints);
+        new Span<Vector2>(waypoints).Reverse();
 
         return waypoints;
     }

--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -8,8 +8,9 @@ namespace Neuro.Pathfinding;
 
 public class PathfindingHandler
 {
-    private const int GRID_DENSITY = 6; // TODO: Make this a float to allow fine-tuning individual maps
-    private const int GRID_SIZE = 100 * GRID_DENSITY;
+    private const float GRID_DENSITY = 6f; // TODO: Fine-tune individual maps to optimize performance
+    private const int GRID_BASE_WIDTH = 100;
+    private const int GRID_SIZE = (int)(GRID_BASE_WIDTH * GRID_DENSITY);
     private const int GRID_LOWER_BOUNDS = GRID_SIZE / -2;
     private const int GRID_UPPER_BOUNDS = GRID_SIZE / 2;
 
@@ -121,12 +122,12 @@ public class PathfindingHandler
     {
         grid = new Node[GRID_SIZE, GRID_SIZE];
 
-        const float NODE_RADIUS = 1f / GRID_DENSITY;
+        const float NODE_RADIUS = 1 / GRID_DENSITY;
 
         for (int x = GRID_LOWER_BOUNDS; x < GRID_UPPER_BOUNDS; x++)
         for (int y = GRID_LOWER_BOUNDS; y < GRID_UPPER_BOUNDS; y++)
         {
-            Vector2 point = new(x / (float)GRID_DENSITY, y / (float)GRID_DENSITY);
+            Vector2 point = new(x / GRID_DENSITY, y / GRID_DENSITY);
 
             //Info(point.ToString());
             Collider2D[] cols = Physics2D.OverlapCircleAll(point, NODE_RADIUS, LayerMask.GetMask("Ship", "ShortObjects"));


### PR DESCRIPTION
This fixes all issues on Skeld and Polus, as well as all issues on Mira except for the garden at the cost of slightly more CPU time.

Be warned that due to Airship still lacking ladder and electrical mappings, it will lag spike harder due to the increase in total nodes. The lag spikes are a result of no path being found, thus resulting in every node on the map being checked.