### PR TITLE
Use floodfill to get closest task

### DIFF
--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Neuro.Pathfinding.DataStructures;
+using Neuro.Utilities;
 using UnityEngine;
 
 namespace Neuro.Pathfinding;
@@ -117,6 +118,41 @@ public sealed class PathfindingHandler
 
         Warning("Failed to find path");
         return Array.Empty<Vector2>();
+    }
+
+    public PlayerTask FindClosestTask(Vector2 start, List<PlayerTask> tasks) {
+        Node startingNode = FindClosestNode(start);
+
+        List<Node> taskNodes = new();
+        foreach (PlayerTask t in tasks) 
+        {
+            taskNodes.Add(FindClosestNode(t.Locations.At(0)));
+        }
+
+        // Flood fill
+        List<Node> openSet = new();
+        HashSet<Node> closedSet = new();
+        openSet.Add(startingNode);
+        while (openSet.Count > 0)
+        {
+            Node node = openSet[0];
+
+            if (taskNodes.Contains(node)) {
+                return tasks[taskNodes.IndexOf(node)];
+            }
+
+            openSet.Remove(node);
+            closedSet.Add(node);
+
+            foreach (Node neighbour in GetNeighbours(node))
+            {
+                if (!neighbour.accessible || closedSet.Contains(neighbour)) continue;
+                if (!openSet.Contains(neighbour)) openSet.Add(neighbour);
+
+                neighbour.parent = node;
+            }
+        }
+        return null;
     }
 
     private void GenerateNodeGrid()

--- a/Neuro/Pathfinding/PathfindingHandler.cs
+++ b/Neuro/Pathfinding/PathfindingHandler.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Neuro.Pathfinding.DataStructures;
-using Neuro.Utilities;
 using UnityEngine;
 
 namespace Neuro.Pathfinding;
@@ -120,13 +119,13 @@ public sealed class PathfindingHandler
         return Array.Empty<Vector2>();
     }
 
-    public PlayerTask FindClosestTask(Vector2 start, List<PlayerTask> tasks) {
+    public int FindClosestTarget(Vector2 start, List<Vector2> targets) {
         Node startingNode = FindClosestNode(start);
 
-        List<Node> taskNodes = new();
-        foreach (PlayerTask t in tasks) 
+        List<Node> targetNodes = new();
+        foreach (Vector2 v in targets) 
         {
-            taskNodes.Add(FindClosestNode(t.Locations.At(0)));
+            targetNodes.Add(FindClosestNode(v));
         }
 
         // Flood fill
@@ -137,8 +136,8 @@ public sealed class PathfindingHandler
         {
             Node node = openSet[0];
 
-            if (taskNodes.Contains(node)) {
-                return tasks[taskNodes.IndexOf(node)];
+            if (targetNodes.Contains(node)) {
+                return targetNodes.IndexOf(node);
             }
 
             openSet.Remove(node);
@@ -152,7 +151,7 @@ public sealed class PathfindingHandler
                 neighbour.parent = node;
             }
         }
-        return null;
+        return -1;
     }
 
     private void GenerateNodeGrid()

--- a/Neuro/Tasks/TasksHandler.cs
+++ b/Neuro/Tasks/TasksHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Il2CppInterop.Runtime.Attributes;
 using Neuro.Utilities;
 using Reactor.Utilities.Attributes;
@@ -75,30 +76,15 @@ public sealed class TasksHandler : MonoBehaviour
     [HideFromIl2Cpp]
     public PlayerTask GetClosestTask()
     {
-        PlayerTask closestTask = null;
-        float closestDistance = Mathf.Infinity;
-
-        foreach (PlayerTask t in PlayerControl.LocalPlayer.myTasks)
+        List<PlayerTask> tasks = new();
+        foreach (PlayerTask t in PlayerControl.LocalPlayer.myTasks) 
         {
             if (!t.IsComplete && t.HasLocation)
             {
-                Vector2[] path = NeuroPlugin.Instance.Pathfinding.FindPath(PlayerControl.LocalPlayer.transform.position, t.Locations.At(0));
-                // Evaluate length of path
-                float distance = 0f;
-                for (int i = 0; i < path.Length - 1; i++)
-                {
-                    distance += Vector2.Distance(path[i], path[i + 1]);
-                }
-
-                if (distance < closestDistance)
-                {
-                    closestDistance = distance;
-                    closestTask = t;
-                }
+                tasks.Add(t);
             }
         }
-
-        return closestTask;
+        return NeuroPlugin.Instance.Pathfinding.FindClosestTask(PlayerControl.LocalPlayer.transform.position, tasks);
     }
 
     [HideFromIl2Cpp]


### PR DESCRIPTION
The current implementation of `GetClosestTask()` pathfinds to every available task and calculates their distance to find the closest task. Since only the distances to the tasks are needed and not the path itself I used floodfill instead to improve the efficiency of `GetClosestTask()`. It expands outwards from the current position until it hits a node that is a valid task and returns this task. This should improve/prevent the stuttering when pathfinding.