### PR TITLE
Remove output path added by 52ccf7f433527a34b0d838aae4198eac70762b3e

### DIFF
--- a/Neuro/Neuro.csproj
+++ b/Neuro/Neuro.csproj
@@ -13,7 +13,6 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         
         <ILRepackTargetConfigurations>Debug;Release</ILRepackTargetConfigurations>
-        <OutputPath>V:\SteamLibrary\steamapps\common\Among Us\BepInEx\plugins</OutputPath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The environment variable copy is still there, no need to hard code the output path.