### PR TITLE
Record if we are alive and our role

### DIFF
--- a/Neuro/Recording/Common/RoleType.proto
+++ b/Neuro/Recording/Common/RoleType.proto
@@ -9,4 +9,6 @@ enum RoleType {
     Engineer = 4;
     GuardianAngel = 5;
     Shapeshifter = 6;
+    CrewmateGhost = 7;
+    ImpostorGhost = 8;
 }

--- a/Neuro/Recording/LocalPlayer/LocalPlayerFrame.proto
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerFrame.proto
@@ -15,5 +15,4 @@ message LocalPlayerFrame {
     Vector2 Position = 7;
     Vector2 Velocity = 8;
     bool IsDead = 9;
-    RoleType Role = 10;
 }

--- a/Neuro/Recording/LocalPlayer/LocalPlayerFrame.proto
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerFrame.proto
@@ -2,6 +2,7 @@
 option csharp_namespace = "Neuro.Recording.LocalPlayer";
 
 import "Recording/Common/SystemType.proto";
+import "Recording/Common/RoleType.proto";
 import "Recording/Common/Vector2.proto";
 
 message LocalPlayerFrame {
@@ -13,4 +14,6 @@ message LocalPlayerFrame {
     repeated float RaycastObstacleDistances = 6;
     Vector2 Position = 7;
     Vector2 Velocity = 8;
+    bool IsDead = 9;
+    RoleType Role = 10;
 }

--- a/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
@@ -61,6 +61,9 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
 
             Frame.RaycastObstacleDistances[i] = raycastHit.distance;
         }
+
+        Frame.IsDead = PlayerControl.LocalPlayer.Data.IsDead;
+        RecordRole();
     }
 
     public void RecordReport() => Frame.DidReport = true;
@@ -68,7 +71,6 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
     public void RecordKill() => Frame.DidKill = true;
     public void RecordSabotage(SystemTypes type) => Frame.SabotageUsed = type.ForMessage();
     public void RecordDoors(SystemTypes room) => Frame.DoorsUsed = room.ForMessage();
-    public void RecordDead() => Frame.IsDead = PlayerControl.LocalPlayer.Data.IsDead;
     public void RecordRole()
     {
         RoleTypes role = PlayerControl.LocalPlayer.Data.RoleType;

--- a/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
@@ -79,7 +79,7 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
         else if (role == RoleTypes.ImpostorGhost)
             Frame.Role = RoleType.Impostor;
         else
-            Frame.Role = (RoleType)(role + 1);
+            Frame.Role = (role + 1).ForMessage();
     }
 
     [EventHandler(EventTypes.GameStarted)]

--- a/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
@@ -61,9 +61,6 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
 
             Frame.RaycastObstacleDistances[i] = raycastHit.distance;
         }
-
-        Frame.IsDead = PlayerControl.LocalPlayer.Data.IsDead;
-        RecordRole();
     }
 
     public void RecordReport() => Frame.DidReport = true;
@@ -71,18 +68,6 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
     public void RecordKill() => Frame.DidKill = true;
     public void RecordSabotage(SystemTypes type) => Frame.SabotageUsed = type.ForMessage();
     public void RecordDoors(SystemTypes room) => Frame.DoorsUsed = room.ForMessage();
-    public void RecordRole()
-    {
-        RoleTypes role = PlayerControl.LocalPlayer.Data.RoleType;
-        // among us considers ghosts as seperate roles, so convert them to our role type
-        // TODO: Maybe implement the ghost roles to the RoleType enum if necessary
-        if (role == RoleTypes.CrewmateGhost)
-            Frame.Role = RoleType.Crewmate;
-        else if (role == RoleTypes.ImpostorGhost)
-            Frame.Role = RoleType.Impostor;
-        else
-            Frame.Role = (role + 1).ForMessage();
-    }
 
     [EventHandler(EventTypes.GameStarted)]
     private static void OnGameStarted()

--- a/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
+++ b/Neuro/Recording/LocalPlayer/LocalPlayerRecorder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AmongUs.GameOptions;
 using Il2CppInterop.Runtime.Attributes;
 using Neuro.Events;
 using Neuro.Recording.Common;
@@ -67,6 +68,19 @@ public sealed class LocalPlayerRecorder : MonoBehaviour
     public void RecordKill() => Frame.DidKill = true;
     public void RecordSabotage(SystemTypes type) => Frame.SabotageUsed = type.ForMessage();
     public void RecordDoors(SystemTypes room) => Frame.DoorsUsed = room.ForMessage();
+    public void RecordDead() => Frame.IsDead = PlayerControl.LocalPlayer.Data.IsDead;
+    public void RecordRole()
+    {
+        RoleTypes role = PlayerControl.LocalPlayer.Data.RoleType;
+        // among us considers ghosts as seperate roles, so convert them to our role type
+        // TODO: Maybe implement the ghost roles to the RoleType enum if necessary
+        if (role == RoleTypes.CrewmateGhost)
+            Frame.Role = RoleType.Crewmate;
+        else if (role == RoleTypes.ImpostorGhost)
+            Frame.Role = RoleType.Impostor;
+        else
+            Frame.Role = (RoleType)(role + 1);
+    }
 
     [EventHandler(EventTypes.GameStarted)]
     private static void OnGameStarted()


### PR DESCRIPTION
This PR implements changes requested in #52. It records if the player is dead in RecordDead, and also records the player's current role in RecordRole.

One thing to note is that Among Us treats ghost roles (Crewmate and Impostor ghosts) as separate roles, and this PR converts these to normal roles when converting them from the RoleTypes enum to our custom RoleType enum. If it is necessary to keep track of the ghost roles separately, then I can add those roles into our RoleType enum.