### PR TITLE
Cache Camera.main

### DIFF
--- a/Neuro/Cursor/InGameCursor.cs
+++ b/Neuro/Cursor/InGameCursor.cs
@@ -47,7 +47,7 @@ public sealed class InGameCursor : MonoBehaviour
 
         gameObject.layer = LayerMask.NameToLayer("UI");
 
-        transform.SetParent(NeuroUtilities.CameraMain.transform, false);
+        transform.SetParent(NeuroUtilities.MainCamera.transform, false);
         transform.localPosition = new Vector3(0f, 0f, -650);
         Hide();
 

--- a/Neuro/Cursor/InGameCursor.cs
+++ b/Neuro/Cursor/InGameCursor.cs
@@ -46,8 +46,9 @@ public sealed class InGameCursor : MonoBehaviour
         Instance = this;
 
         gameObject.layer = LayerMask.NameToLayer("UI");
+        NeuroUtilities.CacheCamera(Camera.main);
 
-        transform.SetParent(Camera.main!.transform, false);
+        transform.SetParent(NeuroUtilities.CameraMain.transform, false);
         transform.localPosition = new Vector3(0f, 0f, -650);
         Hide();
 

--- a/Neuro/Cursor/InGameCursor.cs
+++ b/Neuro/Cursor/InGameCursor.cs
@@ -46,7 +46,6 @@ public sealed class InGameCursor : MonoBehaviour
         Instance = this;
 
         gameObject.layer = LayerMask.NameToLayer("UI");
-        NeuroUtilities.CacheCamera(Camera.main);
 
         transform.SetParent(NeuroUtilities.CameraMain.transform, false);
         transform.localPosition = new Vector3(0f, 0f, -650);

--- a/Neuro/Cursor/Patches/Input_Patches.cs
+++ b/Neuro/Cursor/Patches/Input_Patches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Neuro.Utilities;
 using UnityEngine;
 
 namespace Neuro.Cursor.Patches;
@@ -13,7 +14,7 @@ public static class Input_get_mousePosition
 
         if (!InGameCursor.Instance.IsHidden)
         {
-            __result = Camera.main!.WorldToScreenPoint(InGameCursor.Instance.Position);
+            __result = NeuroUtilities.CameraMain.WorldToScreenPoint(InGameCursor.Instance.Position);
         }
     }
 }

--- a/Neuro/Cursor/Patches/Input_Patches.cs
+++ b/Neuro/Cursor/Patches/Input_Patches.cs
@@ -14,7 +14,7 @@ public static class Input_get_mousePosition
 
         if (!InGameCursor.Instance.IsHidden)
         {
-            __result = NeuroUtilities.CameraMain.WorldToScreenPoint(InGameCursor.Instance.Position);
+            __result = NeuroUtilities.MainCamera.WorldToScreenPoint(InGameCursor.Instance.Position);
         }
     }
 }

--- a/Neuro/Minigames/Solvers/CommsSabotagedMiraSolver.cs
+++ b/Neuro/Minigames/Solvers/CommsSabotagedMiraSolver.cs
@@ -1,6 +1,5 @@
 ﻿using Neuro.Cursor;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using Neuro.Utilities;
 using UnityEngine;
@@ -33,7 +32,7 @@ public sealed class CommsSabotagedMiraSolver : IMinigameSolver<AuthGame>, IMinig
                     break;
                 }
             }
-            
+
             if (codeNumber == minigame.system.TargetNumber)
             {
                 yield return InGameCursor.Instance.CoMoveTo(minigame.ControllerSelectable.At(^1));

--- a/Neuro/Minigames/TasksDebugTab.cs
+++ b/Neuro/Minigames/TasksDebugTab.cs
@@ -22,7 +22,7 @@ public sealed class TasksDebugTab : DebugTab
         {
             Minigame minigamePrefab = ShipStatus.Instance.GetComponentsInChildren<SystemConsole>().First(c => c.FreeplayOnly).MinigamePrefab;
             PlayerControl.LocalPlayer.NetTransform.Halt();
-            Minigame minigame = Object.Instantiate(minigamePrefab, NeuroUtilities.CameraMain.transform, false);
+            Minigame minigame = Object.Instantiate(minigamePrefab, NeuroUtilities.MainCamera.transform, false);
             minigame.transform.localPosition = new Vector3(0f, 0f, -50f);
             minigame.Begin(null);
         }
@@ -39,7 +39,7 @@ public sealed class TasksDebugTab : DebugTab
 
                 Console console = ShipStatus.Instance.AllConsoles.First(task.ValidConsole);
 
-                Minigame minigame = Object.Instantiate(task.GetMinigamePrefab(), NeuroUtilities.CameraMain.transform, false);
+                Minigame minigame = Object.Instantiate(task.GetMinigamePrefab(), NeuroUtilities.MainCamera.transform, false);
                 minigame.transform.localPosition = new Vector3(0f, 0f, -50f);
                 minigame.Console = console;
                 minigame.Begin(task);

--- a/Neuro/Minigames/TasksDebugTab.cs
+++ b/Neuro/Minigames/TasksDebugTab.cs
@@ -22,7 +22,7 @@ public sealed class TasksDebugTab : DebugTab
         {
             Minigame minigamePrefab = ShipStatus.Instance.GetComponentsInChildren<SystemConsole>().First(c => c.FreeplayOnly).MinigamePrefab;
             PlayerControl.LocalPlayer.NetTransform.Halt();
-            Minigame minigame = Object.Instantiate(minigamePrefab, Camera.main!.transform, false);
+            Minigame minigame = Object.Instantiate(minigamePrefab, NeuroUtilities.CameraMain.transform, false);
             minigame.transform.localPosition = new Vector3(0f, 0f, -50f);
             minigame.Begin(null);
         }
@@ -39,7 +39,7 @@ public sealed class TasksDebugTab : DebugTab
 
                 Console console = ShipStatus.Instance.AllConsoles.First(task.ValidConsole);
 
-                Minigame minigame = Object.Instantiate(task.GetMinigamePrefab(), Camera.main!.transform, false);
+                Minigame minigame = Object.Instantiate(task.GetMinigamePrefab(), NeuroUtilities.CameraMain.transform, false);
                 minigame.transform.localPosition = new Vector3(0f, 0f, -50f);
                 minigame.Console = console;
                 minigame.Begin(task);

--- a/Neuro/Utilities/NeuroUtilities.cs
+++ b/Neuro/Utilities/NeuroUtilities.cs
@@ -31,4 +31,25 @@ public static class NeuroUtilities
     {
         GUILayout.Label(string.Empty, GUI.skin.horizontalSlider);
     }
+
+    public static void CacheCamera(Camera camera)
+    {
+        cache = camera;
+    }
+
+    private static Camera cache;
+
+    public static Camera CameraMain
+    {
+        get
+        {
+            // safety check
+            // until we have our cached version of the camera, use default behavior
+            if (cache == null)
+            {
+                return Camera.main;
+            }
+            return cache;
+        }
+    }
 }

--- a/Neuro/Utilities/NeuroUtilities.cs
+++ b/Neuro/Utilities/NeuroUtilities.cs
@@ -22,6 +22,9 @@ public static class NeuroUtilities
     }
     private static Material _maskShaderMat;
 
+    public static Camera MainCamera => _mainCamera ? _mainCamera : _mainCamera = Camera.main;
+    private static Camera _mainCamera;
+
     public static void WarnDoubleSingletonInstance([CallerFilePath] string file = null)
     {
         Warning($"Tried to create an instance of {Path.GetFileNameWithoutExtension(file)} when it already exists");
@@ -30,19 +33,5 @@ public static class NeuroUtilities
     public static void GUILayoutDivider()
     {
         GUILayout.Label(string.Empty, GUI.skin.horizontalSlider);
-    }
-
-    private static Camera cache;
-
-    public static Camera CameraMain
-    {
-        get
-        {
-            if (cache == null)
-            {
-                cache = Camera.main;
-            }
-            return cache;
-        }
     }
 }

--- a/Neuro/Utilities/NeuroUtilities.cs
+++ b/Neuro/Utilities/NeuroUtilities.cs
@@ -32,22 +32,15 @@ public static class NeuroUtilities
         GUILayout.Label(string.Empty, GUI.skin.horizontalSlider);
     }
 
-    public static void CacheCamera(Camera camera)
-    {
-        cache = camera;
-    }
-
     private static Camera cache;
 
     public static Camera CameraMain
     {
         get
         {
-            // safety check
-            // until we have our cached version of the camera, use default behavior
             if (cache == null)
             {
-                return Camera.main;
+                cache = Camera.main;
             }
             return cache;
         }

--- a/Neuro/Utilities/Visibility.cs
+++ b/Neuro/Utilities/Visibility.cs
@@ -9,7 +9,7 @@ public static class Visibility
     // TODO: Improve (idea: send raycast from camera to target)
     private static bool IsVisible(Vector2 rayStart, Vector2 rayEnd)
     {
-        Vector3 viewport = NeuroUtilities.CameraMain.WorldToViewportPoint(rayEnd);
+        Vector3 viewport = NeuroUtilities.MainCamera.WorldToViewportPoint(rayEnd);
         bool visible = viewport.x is > 0 and < 1 && viewport.y is > 0 and < 1;
         if (!visible) return false;
 

--- a/Neuro/Utilities/Visibility.cs
+++ b/Neuro/Utilities/Visibility.cs
@@ -9,7 +9,7 @@ public static class Visibility
     // TODO: Improve (idea: send raycast from camera to target)
     private static bool IsVisible(Vector2 rayStart, Vector2 rayEnd)
     {
-        Vector3 viewport = Camera.main!.WorldToViewportPoint(rayEnd);
+        Vector3 viewport = NeuroUtilities.CameraMain.WorldToViewportPoint(rayEnd);
         bool visible = viewport.x is > 0 and < 1 && viewport.y is > 0 and < 1;
         if (!visible) return false;
 


### PR DESCRIPTION
This PR caches Camera.main within the NeuroUtilities class. 

As you probably know, ~~Unity's `Camera.main` calls `FindGameObjectsWithTag("MainCamera")` internally and does not cache it, which causes small but unnecessary CPU overhead, especially when called frequently~~ This was improved drastically as of 2020.2, but still is almost the same as calling `GetComponent.` Currently, the project calls this upwards of 180 times in Visibility.IsVisible and _every frame_ when the fake Cursor is on screen. While not very noticeable framewise, caching the main camera is recommended by Unity themselves and again relieves slight CPU overhead. 