### PR TITLE
Speed up conversion to nn format

### DIFF
--- a/AI/data/game.py
+++ b/AI/data/game.py
@@ -25,9 +25,11 @@ class Game:
     def get_x(self, shuffle=False):
         # return np.vstack([state.get_x() for state in self.states])
         # updated to return sequences of states of length WINDOW_LENGTH
-        return np.array([np.vstack([self.states[i + j].get_x() for j in range(50)]) for i in range(len(self.states) - 50)])
+        state_xs = [state.get_x() for state in self.states]
+        return np.array([np.vstack([state_xs[i + j] for j in range(50)]) for i in range(len(self.states) - 50)])
 
     def get_y(self, shuffle=False):
         # return np.vstack([state.get_y() for state in self.states])
         # updated to the corresponding y value
-        return np.array([self.states[i + 50].get_y() for i in range(len(self.states) - 50)])
+        state_ys = [state.get_y() for state in self.states]
+        return np.array([state_ys[i + 50] for i in range(len(self.states) - 50)])

--- a/AI/data/game.py
+++ b/AI/data/game.py
@@ -26,10 +26,10 @@ class Game:
         # return np.vstack([state.get_x() for state in self.states])
         # updated to return sequences of states of length WINDOW_LENGTH
         state_xs = [state.get_x() for state in self.states]
-        return np.array([np.vstack([state_xs[i + j] for j in range(50)]) for i in range(len(self.states) - 50)])
+        return np.array([np.vstack([state_xs[i + j] for j in range(WINDOW_LENGTH)]) for i in range(len(self.states) - WINDOW_LENGTH)])
 
     def get_y(self, shuffle=False):
         # return np.vstack([state.get_y() for state in self.states])
         # updated to the corresponding y value
         state_ys = [state.get_y() for state in self.states]
-        return np.array([state_ys[i + 50] for i in range(len(self.states) - 50)])
+        return np.array([state_ys[i + WINDOW_LENGTH] for i in range(len(self.states) - WINDOW_LENGTH)])


### PR DESCRIPTION
This speeds up `get_x` for `Game` objects by avoiding recomputing the x values for each point in the window.
## Comparision
I've provided a small benchmark on a 2MB file with ~1700 frames, which should hopefully be relatively representative.
### Existing version
```
(neuro-amongus-py3.11) bred@fluff:~/amongie/neuro-amongus$ python AI/test.py 
Parsing: recordings/1684614514.gymbag2
Updating game data
Saving: recordings/decoded/1684614514.pickle
Converting to neural network format...
Conversion took 14.9826s
Saving neural network format...
```
### New version
```
(neuro-amongus-py3.11) bred@fluff:~/amongie/neuro-amongus$ python AI/test.py 
Parsing: recordings/1684614514.gymbag2
Updating game data
Saving: recordings/decoded/1684614514.pickle
Converting to neural network format...
Conversion took 3.3117s
Saving neural network format...
```
This version is 4.5x (~11 seconds) faster than the original version.

### Mild sanity check
This version produces a file in `recordings/data/1684614514.pickle` with an md5 that is identical to the hash of the file produced by the original version.